### PR TITLE
feat: add dynamic project init suggestions based on docs/openhands-first-query.md

### DIFF
--- a/frontend/src/components/features/chat/chat-suggestions.tsx
+++ b/frontend/src/components/features/chat/chat-suggestions.tsx
@@ -1,12 +1,20 @@
 import { Suggestions } from "#/components/features/suggestions/suggestions";
 import BuildIt from "#/icons/build-it.svg?react";
-import { SUGGESTIONS } from "#/utils/suggestions";
+import { INITIAL_SUGGESTIONS, getSuggestions } from "#/utils/suggestions";
+import { useEffect, useState } from "react";
 
 interface ChatSuggestionsProps {
   onSuggestionsClick: (value: string) => void;
 }
 
 export function ChatSuggestions({ onSuggestionsClick }: ChatSuggestionsProps) {
+  const [suggestions, setSuggestions] = useState(INITIAL_SUGGESTIONS);
+
+  useEffect(() => {
+    // Load dynamic suggestions when component mounts
+    getSuggestions().then(setSuggestions).catch(console.error);
+  }, []);
+
   return (
     <div className="flex flex-col gap-6 h-full px-4 items-center justify-center">
       <div className="flex flex-col items-center p-4 bg-neutral-700 rounded-xl w-full">
@@ -16,7 +24,7 @@ export function ChatSuggestions({ onSuggestionsClick }: ChatSuggestionsProps) {
         </span>
       </div>
       <Suggestions
-        suggestions={Object.entries(SUGGESTIONS.repo)
+        suggestions={Object.entries(suggestions.repo)
           .slice(0, 4)
           .map(([label, value]) => ({
             label,

--- a/frontend/src/components/shared/task-form.tsx
+++ b/frontend/src/components/shared/task-form.tsx
@@ -9,7 +9,7 @@ import {
   setInitialQuery,
 } from "#/state/initial-query-slice";
 import { SuggestionBubble } from "#/components/features/suggestions/suggestion-bubble";
-import { SUGGESTIONS } from "#/utils/suggestions";
+import { INITIAL_SUGGESTIONS, getSuggestions } from "#/utils/suggestions";
 import { convertImageToBase64 } from "#/utils/convert-image-to-base-64";
 import { ChatInput } from "#/components/features/chat/chat-input";
 import { getRandomKey } from "#/utils/get-random-key";
@@ -28,15 +28,21 @@ export const TaskForm = React.forwardRef<HTMLFormElement>((_, ref) => {
   );
 
   const [text, setText] = React.useState("");
+  const [suggestions, setSuggestions] = React.useState(INITIAL_SUGGESTIONS);
   const [suggestion, setSuggestion] = React.useState(
-    getRandomKey(SUGGESTIONS["non-repo"]),
+    getRandomKey(INITIAL_SUGGESTIONS["non-repo"]),
   );
   const [inputIsFocused, setInputIsFocused] = React.useState(false);
 
+  React.useEffect(() => {
+    // Load dynamic suggestions when component mounts
+    getSuggestions().then(setSuggestions).catch(console.error);
+  }, []);
+
   const onRefreshSuggestion = () => {
-    const suggestions = SUGGESTIONS["non-repo"];
+    const currentSuggestions = suggestions["non-repo"];
     // remove current suggestion to avoid refreshing to the same suggestion
-    const suggestionCopy = { ...suggestions };
+    const suggestionCopy = { ...currentSuggestions };
     delete suggestionCopy[suggestion];
 
     const key = getRandomKey(suggestionCopy);
@@ -44,8 +50,8 @@ export const TaskForm = React.forwardRef<HTMLFormElement>((_, ref) => {
   };
 
   const onClickSuggestion = () => {
-    const suggestions = SUGGESTIONS["non-repo"];
-    const value = suggestions[suggestion];
+    const currentSuggestions = suggestions["non-repo"];
+    const value = currentSuggestions[suggestion];
     setText(value);
   };
 

--- a/frontend/src/utils/suggestions/index.ts
+++ b/frontend/src/utils/suggestions/index.ts
@@ -1,10 +1,23 @@
 import { NON_REPO_SUGGESTIONS } from "./non-repo-suggestions";
-import { REPO_SUGGESTIONS } from "./repo-suggestions";
+import { BASE_REPO_SUGGESTIONS, getRepoSuggestions } from "./repo-suggestions";
 
-export const SUGGESTIONS: Record<
+// Initial suggestions with base repo suggestions
+export const INITIAL_SUGGESTIONS: Record<
   "repo" | "non-repo",
   Record<string, string>
 > = {
-  repo: REPO_SUGGESTIONS,
+  repo: BASE_REPO_SUGGESTIONS,
   "non-repo": NON_REPO_SUGGESTIONS,
 };
+
+// Function to get all suggestions including dynamic ones
+export async function getSuggestions(): Promise<Record<
+  "repo" | "non-repo",
+  Record<string, string>
+>> {
+  const repoSuggestions = await getRepoSuggestions();
+  return {
+    repo: repoSuggestions,
+    "non-repo": NON_REPO_SUGGESTIONS,
+  };
+}

--- a/frontend/src/utils/suggestions/repo-suggestions.ts
+++ b/frontend/src/utils/suggestions/repo-suggestions.ts
@@ -39,7 +39,8 @@ const VALUE_6 = `Investigate the current repo to understand the installation ins
 
 If there is an existing Dockerfile, and there are ways to improve it according to best practices, do so.`;
 
-export const REPO_SUGGESTIONS: Record<string, string> = {
+// Base suggestions that are always available
+export const BASE_REPO_SUGGESTIONS: Record<string, string> = {
   [KEY_1]: VALUE_1,
   [KEY_2]: VALUE_2,
   [KEY_3]: VALUE_3,
@@ -47,3 +48,36 @@ export const REPO_SUGGESTIONS: Record<string, string> = {
   [KEY_5]: VALUE_5,
   [KEY_6]: VALUE_6,
 };
+
+// Function to create a dynamic suggestion for initializing a project
+export function createInitSuggestion(projectPath: string): [string, string] {
+  const key = `Init app with prompt in ${projectPath}/docs/openhands-first-query.md`;
+  const value = `Please read the prompt from ${projectPath}/docs/openhands-first-query.md and use it to initialize the application according to the specifications in that file.`;
+  return [key, value];
+}
+
+// Function to get all suggestions including dynamic ones
+export async function getRepoSuggestions(): Promise<Record<string, string>> {
+  try {
+    // Get projects with init files
+    const response = await fetch('/api/scan-init-projects');
+    if (!response.ok) {
+      console.error('Failed to scan for init projects:', await response.text());
+      return BASE_REPO_SUGGESTIONS;
+    }
+
+    const projectPaths = await response.json();
+    const suggestions = { ...BASE_REPO_SUGGESTIONS };
+
+    // Add dynamic suggestions for each project
+    for (const path of projectPaths) {
+      const [key, value] = createInitSuggestion(path);
+      suggestions[key] = value;
+    }
+
+    return suggestions;
+  } catch (error) {
+    console.error('Error getting repo suggestions:', error);
+    return BASE_REPO_SUGGESTIONS;
+  }
+}


### PR DESCRIPTION
This PR adds support for dynamic project initialization suggestions based on the presence of `docs/openhands-first-query.md` files in projects.

### Changes:

- Add backend endpoint `/api/scan-init-projects` to scan for projects with init files
- Convert static suggestions to dynamic with `BASE_REPO_SUGGESTIONS`
- Add async `getSuggestions` function to fetch dynamic suggestions
- Update UI components to handle dynamic suggestions

Now when a user opens OpenHands:
1. The UI will show the base suggestions immediately
2. In the background, it will scan for projects containing `docs/openhands-first-query.md`
3. For each project found, it will add a new suggestion like "Init app with prompt in /path/to/project/docs/openhands-first-query.md"
4. The suggestions will be updated automatically when they are loaded